### PR TITLE
ZCS-2592

### DIFF
--- a/js/com_zimbra_clientuploader_da.properties
+++ b/js/com_zimbra_clientuploader_da.properties
@@ -22,7 +22,7 @@ BTN_upload = Upload
 
 Client_upload_title = Klient-software-upload
 Client_upload_desc = V\u00e6lg den seneste version af klient-softwaren, og klik p\u00e5 upload.
-Client_upload_in_process = Upload'et kan tage flere minutter. Hvis du forlader dette vindue, vil et popup-vindue informere dig, n\u00e5r responsen modtages.
+Client_upload_in_process = Upload\u2019et kan tage flere minutter. Hvis du forlader dette vindue, vil et popup-vindue informere dig, n\u00e5r responsen modtages.
 Client_upload_succeeded = Klient-software er blevet uploadet til serveren.
 Client_upload_failed = Kunne ikke uploade klientsoftwaren, du kan pr\u00f8ve igen senere.
 Client_upload_too_large = Klient-softwarens st\u00f8rrelse overstiger den maks. tilladte st\u00f8rrelse.

--- a/js/com_zimbra_clientuploader_fr.properties
+++ b/js/com_zimbra_clientuploader_fr.properties
@@ -15,16 +15,16 @@
 # ***** END LICENSE BLOCK *****
 # 
 label = Envoi/upload du client
-description = Extension permettant aux administrateurs d'envoyer/uploader le logiciel client vers le serveur.
-UI_Comp_clientUpload = Vue de l'envoi/upload du client
+description = Extension permettant aux administrateurs d\u2019envoyer/uploader le logiciel client vers le serveur.
+UI_Comp_clientUpload = Vue de l\u2019envoi/upload du client
 OVP_clientUpload = Envoi/upload du client
 BTN_upload = Envoyer
 
 Client_upload_title = Envoi/upload du logiciel client
 Client_upload_desc = Veuillez s\u00e9lectionner la derni\u00e8re version du logiciel client et cliquer sur envoyer/uploader.
-Client_upload_in_process = L'envoi/upload peut durer plusieurs minutes. Si vous quittez cette vue, une fen\u00eatre popup vous informera d\u00e8s que vous recevrez une r\u00e9ponse.
+Client_upload_in_process = L\u2019envoi/upload peut durer plusieurs minutes. Si vous quittez cette vue, une fen\u00eatre popup vous informera d\u00e8s que vous recevrez une r\u00e9ponse.
 Client_upload_succeeded = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9 vers le serveur.
-Client_upload_failed = Impossible d'uploader le logiciel client. Patientez quelques instants et r\u00e9essayez.
+Client_upload_failed = Impossible d\u2019uploader le logiciel client. Patientez quelques instants et r\u00e9essayez.
 Client_upload_too_large = La taille du logiciel client d\u00e9passe celle autoris\u00e9e.
-Client_upload_update_failed = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9, mais impossible d'ex\u00e9cuter le script visant \u00e0 mettre \u00e0 jour la page de t\u00e9l\u00e9chargement.
-Client_upload_no_permission = Impossible de proc\u00e9der \u00e0 l'envoi/upload. Aucune autorisation pour l'envoi/upload de logiciel client.
+Client_upload_update_failed = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9, mais impossible d\u2019ex\u00e9cuter le script visant \u00e0 mettre \u00e0 jour la page de t\u00e9l\u00e9chargement.
+Client_upload_no_permission = Impossible de proc\u00e9der \u00e0 l\u2019envoi/upload. Aucune autorisation pour l\u2019envoi/upload de logiciel client.

--- a/js/com_zimbra_clientuploader_fr_CA.properties
+++ b/js/com_zimbra_clientuploader_fr_CA.properties
@@ -15,8 +15,8 @@
 # ***** END LICENSE BLOCK *****
 # 
 label = Envoi/upload du client
-description = Extension permettant aux administrateurs d'envoyer/uploader le logiciel client vers le serveur.
-UI_Comp_clientUpload = Vue de l'envoi/upload du client
+description = Extension permettant aux administrateurs d\u2019envoyer/uploader le logiciel client vers le serveur.
+UI_Comp_clientUpload = Vue de l\u2019envoi/upload du client
 OVP_clientUpload = Envoi/upload du client
 BTN_upload = Envoyer
 
@@ -26,5 +26,5 @@ Client_upload_in_process = Le t\u00e9l\u00e9chargement en amont peut durer plusi
 Client_upload_succeeded = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9 vers le serveur.
 Client_upload_failed = \u00c9chec de t\u00e9l\u00e9chargement du logiciel client, veuillez r\u00e9essayer plus tard.
 Client_upload_too_large = La taille du logiciel client d\u00e9passe celle autoris\u00e9e.
-Client_upload_update_failed = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9, mais impossible d'ex\u00e9cuter le script visant \u00e0 mettre \u00e0 jour la page de t\u00e9l\u00e9chargement.
+Client_upload_update_failed = Le logiciel client a \u00e9t\u00e9 correctement envoy\u00e9/upload\u00e9, mais impossible d\u2019ex\u00e9cuter le script visant \u00e0 mettre \u00e0 jour la page de t\u00e9l\u00e9chargement.
 Client_upload_no_permission = \u00c9chec de t\u00e9l\u00e9chargement en amont. Aucune autorisation pour le t\u00e9l\u00e9chargement du logiciel client.

--- a/js/com_zimbra_clientuploader_it.properties
+++ b/js/com_zimbra_clientuploader_it.properties
@@ -15,7 +15,7 @@
 # ***** END LICENSE BLOCK *****
 # 
 label = Caricamento client
-description = Un'estensione per amministratori per il caricamento del software client su server.
+description = Un\u2019estensione per amministratori per il caricamento del software client su server.
 UI_Comp_clientUpload = Vista Caricamento client
 OVP_clientUpload = Caricamento client
 BTN_upload = Carica
@@ -26,5 +26,5 @@ Client_upload_in_process = Il caricamento potrebbe impiegare alcuni minuti. Se q
 Client_upload_succeeded = Il software client \u00e8 stato caricato correttamente sul server.
 Client_upload_failed = Impossibile caricare il software client, riprova pi\u00f9 tardi.
 Client_upload_too_large = Le dimensioni del software client superano le dimensioni massime consentite.
-Client_upload_update_failed = Il software client \u00e8 stato caricato ma si \u00e8 verificato un errore nell'esecuzione dello script per l'aggiornamento della pagina di download.
-Client_upload_no_permission = Caricamento non riuscito. L'utente non dispone delle autorizzazioni necessarie per caricare il software client.
+Client_upload_update_failed = Il software client \u00e8 stato caricato ma si \u00e8 verificato un errore nell\u2019esecuzione dello script per l\u2019aggiornamento della pagina di download.
+Client_upload_no_permission = Caricamento non riuscito. L\u2019utente non dispone delle autorizzazioni necessarie per caricare il software client.

--- a/js/com_zimbra_clientuploader_pl.properties
+++ b/js/com_zimbra_clientuploader_pl.properties
@@ -21,7 +21,7 @@ OVP_clientUpload = Przesy\u0142anie klienta
 BTN_upload = Prze\u015blij
 
 Client_upload_title = Przesy\u0142anie oprogramowania klienta
-Client_upload_desc = Prosz\u0119 wybra\u0107 najnowsz\u0105 wersj\u0119 oprogramowania klienta i nacisn\u0105\u0107 'prze\u015blij'.
+Client_upload_desc = Prosz\u0119 wybra\u0107 najnowsz\u0105 wersj\u0119 oprogramowania klienta i nacisn\u0105\u0107 \u2018prze\u015blij\u2019.
 Client_upload_in_process = Przesy\u0142anie mo\u017ce potrwa\u0107 kilka minut. Je\u015bli opu\u015bcisz ten ekran, w chwili otrzymania odpowiedzi wyskoczy okienko z komunikatem.
 Client_upload_succeeded = Oprogramowanie klienta zosta\u0142o pomy\u015blnie przes\u0142ane na serwer.
 Client_upload_failed = Nie uda\u0142o si\u0119 przes\u0142a\u0107 oprogramowania klienta, spr\u00f3buj ponownie p\u00f3\u017aniej.

--- a/js/com_zimbra_clientuploader_tr.properties
+++ b/js/com_zimbra_clientuploader_tr.properties
@@ -21,7 +21,7 @@ OVP_clientUpload = \u0130stemci Kar\u015f\u0131ya Y\u00fckleme
 BTN_upload = Kar\u015f\u0131ya Y\u00fckle
 
 Client_upload_title = \u0130stemci Yaz\u0131l\u0131m\u0131 Kar\u015f\u0131ya Y\u00fckleme
-Client_upload_desc = L\u00fctfen istemci yaz\u0131l\u0131m\u0131n\u0131n en son s\u00fcr\u00fcm\u00fcn\u00fc se\u00e7in ve kar\u015f\u0131ya y\u00fckle'yi t\u0131klat\u0131n.
+Client_upload_desc = L\u00fctfen istemci yaz\u0131l\u0131m\u0131n\u0131n en son s\u00fcr\u00fcm\u00fcn\u00fc se\u00e7in ve kar\u015f\u0131ya y\u00fckle\u2019yi t\u0131klat\u0131n.
 Client_upload_in_process = Kar\u015f\u0131ya y\u00fckleme i\u015flemi birka\u00e7 dakika s\u00fcrebilir. Bu g\u00f6r\u00fcn\u00fcmden \u00e7\u0131karsan\u0131z, yan\u0131t al\u0131nd\u0131\u011f\u0131nda bir a\u00e7\u0131l\u0131r pencere size bilgi verecektir.
 Client_upload_succeeded = \u0130stemci yaz\u0131l\u0131m\u0131 sunucuya ba\u015far\u0131yla y\u00fcklendi.
 Client_upload_failed = \u0130stemci yaz\u0131l\u0131m\u0131 kar\u015f\u0131ya y\u00fcklenemedi; daha sonra tekrar deneyebilirsiniz.


### PR DESCRIPTION
- Use smart quotes (\u2019/ - \u2018/\u2019 ) instead of single quotes in translation files
- minor fixes with spacing/quote&formatting tag pairing